### PR TITLE
Redirect to the webmention URL after successful submission

### DIFF
--- a/example-template/_index.twig
+++ b/example-template/_index.twig
@@ -7,6 +7,10 @@
   <section class="container">
     <h1>Webmention Endpoint</h1>
 
+    {% if craft.app.request.getQueryParam('success') %}
+      <p>Thanks for the webmention!</p>
+    {% endif %}
+
     {% set notice = craft.app.session.getFlash('notice') %}
     {% if notice %}
     <div class="callout notice">

--- a/src/controllers/WebmentionController.php
+++ b/src/controllers/WebmentionController.php
@@ -3,6 +3,7 @@
 namespace matthiasott\webmention\controllers;
 
 use craft\helpers\Queue;
+use craft\helpers\UrlHelper;
 use craft\web\Controller;
 use matthiasott\webmention\jobs\ReceiveWebmention;
 use matthiasott\webmention\Plugin;
@@ -19,7 +20,10 @@ class WebmentionController extends Controller
     public function actionHandleRequest(): ?Response
     {
         if ($this->request->isPost) {
-            return $this->actionHandleWebmention();
+            $this->actionHandleWebmention();
+            return $this->redirectToPostedUrl(null, UrlHelper::url($this->request->absoluteUrl, [
+                'success' => 1,
+            ]));
         }
 
         if ($this->request->isGet) {


### PR DESCRIPTION
After successfully submitting a webmention via the webmention endpoint URL, the controller will redirect back to itself with `success=1` in the URL.

Webmention templates can then check for `craft.app.request.getQueryParam('success')` and display a success message if present.