### PR TITLE
Make `text` a `TEXT` column

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -51,7 +51,7 @@ class Plugin extends BasePlugin
     public bool $hasCpSection = true;
     public bool $hasCpSettings = true;
     public bool $hasReadOnlyCpSettings = true;
-    public string $schemaVersion = '1.0.0.4';
+    public string $schemaVersion = '1.0.0.5';
 
     public function init(): void
     {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -51,7 +51,7 @@ class Plugin extends BasePlugin
     public bool $hasCpSection = true;
     public bool $hasCpSettings = true;
     public bool $hasReadOnlyCpSettings = true;
-    public string $schemaVersion = '1.0.0.5';
+    public string $schemaVersion = '1.0.0.6';
 
     public function init(): void
     {

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -27,7 +27,7 @@ class Install extends Migration
             'name' => $this->string(),
             'host' => $this->string(),
             'type' => $this->string(),
-            'text' => $this->string(),
+            'text' => $this->text(),
             'hEntryUrl' => $this->string(),
             'rsvp' => $this->string(),
             'properties' => $this->json(),

--- a/src/migrations/m250307_195743_text_column.php
+++ b/src/migrations/m250307_195743_text_column.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace matthiasott\webmention\migrations;
+
+use Craft;
+use craft\db\Migration;
+use matthiasott\webmention\records\Webmention;
+
+/**
+ * m250307_195743_text_column migration.
+ */
+class m250307_195743_text_column extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp(): bool
+    {
+        $this->alterColumn(Webmention::tableName(), 'text', $this->text());
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown(): bool
+    {
+        echo "m250307_195743_text_column cannot be reverted.\n";
+        return false;
+    }
+}

--- a/src/migrations/m250307_201628_name_column_varchar.php
+++ b/src/migrations/m250307_201628_name_column_varchar.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace matthiasott\webmention\migrations;
+
+use Craft;
+use craft\db\Migration;
+use matthiasott\webmention\records\Webmention;
+
+/**
+ * m250307_201628_name_column_varchar migration.
+ */
+class m250307_201628_name_column_varchar extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp(): bool
+    {
+        $this->alterColumn(Webmention::tableName(), 'name', $this->string());
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown(): bool
+    {
+        echo "m250307_201628_name_column_varchar cannot be reverted.\n";
+        return false;
+    }
+}


### PR DESCRIPTION
Fixes a SQL error that occurs if the webmention text is > 255 chars:

```
String data, right truncated: 1406 Data too long for column 'text' at row 1
```