### PR TITLE
Fix the “Source” metadata link label

### DIFF
--- a/src/elements/Webmention.php
+++ b/src/elements/Webmention.php
@@ -160,7 +160,7 @@ class Webmention extends Element
         if ($shorten) {
             $label = parse_url($this->source, PHP_URL_HOST);
         } else {
-            $label = preg_replace('/^https?:\/\//', '', $this->target);
+            $label = preg_replace('/^https?:\/\//', '', $this->source);
         }
 
         return Html::a(Html::encode($label), $this->source, ['target' => '_blank']);


### PR DESCRIPTION
Fixes the link label for the “Source” metadata item. (It was displaying the target URL instead, while still linking to the source URL correctly.)