### PR TITLE
Use the nickname as a fallback

### DIFF
--- a/src/services/Webmentions.php
+++ b/src/services/Webmentions.php
@@ -288,9 +288,7 @@ class Webmentions extends Component
 
         // If author name is empty use the one from the representative h-card
         if (empty($result['author']['name'])) {
-            if ($representative) {
-                $result['author']['name'] = $representative['properties']['name'][0];
-            }
+            $result['author']['name'] = $representative['properties']['name'][0] ?? $representative['properties']['nickname'][0] ?? null;
         }
         // If author url is empty use the one from the representative h-card
         if (empty($result['author']['url'])) {


### PR DESCRIPTION
If the author name isn’t known, this will have the h-card’s `nickname` property be used as a fallback.