### PR TITLE
Bump URL columns to varchar(384)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - `authorName` values now use the h-card’s `nickname` property as a fallback. ([#10](https://github.com/matthiasott/webmention/pull/10))
 - Fixed a bug where webmention validation wasn’t catching `ConnectException` errors.
 - Fixed a bug where jobs for webmentions whithout a valid backlink to the target got stuck in the queue.
+- Fixed a bug where Bluesky source URLs from Brid.gy weren’t always being stored in their entirety.
 
 ## 1.0.2 – 2025-03-21
 - Fixed a bug where getting the the avatar photo from the parsed representative h-card would fail because the URL was the value inside of an array instead of being a string. Now the plugin supports both cases.

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -51,7 +51,7 @@ class Plugin extends BasePlugin
     public bool $hasCpSection = true;
     public bool $hasCpSettings = true;
     public bool $hasReadOnlyCpSettings = true;
-    public string $schemaVersion = '1.0.0.6';
+    public string $schemaVersion = '1.0.0.7';
 
     public function init(): void
     {

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -13,22 +13,25 @@ class Install extends Migration
         $this->safeDown();
 
         $tableName = Webmention::tableName();
+
+        // 3072 / 4 (bytes per char) / 2 (target, source) = 384,
+        // the maximum size we can safely allow in URLs w/o hitting MySQL's max index size limit
         $this->createTable($tableName, [
             'id' => $this->integer()->notNull(),
-            'source' => $this->string()->notNull(),
-            'target' => $this->string()->notNull(),
+            'source' => $this->string(384)->notNull(),
+            'target' => $this->string(384)->notNull(),
             'targetId' => $this->integer(),
             'targetSiteId' => $this->integer(),
-            'avatarUrl' => $this->string(),
+            'avatarUrl' => $this->string(384),
             'avatarId' => $this->integer(),
             'authorName' => $this->string(),
-            'authorUrl' => $this->string(),
+            'authorUrl' => $this->string(384),
             'published' => $this->dateTime(),
             'name' => $this->string(),
             'host' => $this->string(),
             'type' => $this->string(),
             'text' => $this->text(),
-            'hEntryUrl' => $this->string(),
+            'hEntryUrl' => $this->string(384),
             'rsvp' => $this->string(),
             'properties' => $this->json(),
             'PRIMARY KEY([[id]])',

--- a/src/migrations/m250509_221040_url_lengths.php
+++ b/src/migrations/m250509_221040_url_lengths.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace matthiasott\webmention\migrations;
+
+use craft\db\Migration;
+use matthiasott\webmention\records\Webmention;
+
+/**
+ * m250509_221040_url_lengths migration.
+ */
+class m250509_221040_url_lengths extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp(): bool
+    {
+        $tableName = Webmention::tableName();
+
+        if ($this->db->getIsPgsql()) {
+            $this->execute("alter table $tableName alter column [[source]] type varchar(384)");
+            $this->execute("alter table $tableName alter column [[target]] type varchar(384)");
+            $this->execute("alter table $tableName alter column [[avatarUrl]] type varchar(384)");
+            $this->execute("alter table $tableName alter column [[authorUrl]] type varchar(384)");
+            $this->execute("alter table $tableName alter column [[hEntryUrl]] type varchar(384)");
+        } else {
+            $this->alterColumn($tableName, 'source', $this->string(384)->notNull());
+            $this->alterColumn($tableName, 'target', $this->string(384)->notNull());
+            $this->alterColumn($tableName, 'avatarUrl', $this->string(384));
+            $this->alterColumn($tableName, 'authorUrl', $this->string(384));
+            $this->alterColumn($tableName, 'hEntryUrl', $this->string(384));
+        }
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown(): bool
+    {
+        echo "m250509_221040_url_lengths cannot be reverted.\n";
+        return false;
+    }
+}


### PR DESCRIPTION
The default `varchar(255)` wasn’t quite long enough to store longer source URLs from Brid.gy.