### PR TITLE
Condition rule tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Release Notes for Webmention for Craft CMS
 
 ## Unreleased
-- Added the “Host” condition rule type.
-- “Source” and “Target” condition rules no longer have “has a value” or “is empty” operators.
+- Added the “Host” condition rule type. ([#12](https://github.com/matthiasott/webmention/pull/12))
+- “Source” and “Target” condition rules no longer have “has a value” or “is empty” operators. ([#12](https://github.com/matthiasott/webmention/pull/12))
 
 ## 1.0.3 – 2025-05-09
 - `authorName` values now use the h-card’s `nickname` property as a fallback. ([#10](https://github.com/matthiasott/webmention/pull/10))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Release Notes for Webmention for Craft CMS
 
 ## Unreleased
+- Added the “Host” condition rule type.
 - “Source” and “Target” condition rules no longer have “has a value” or “is empty” operators.
 
 ## 1.0.3 – 2025-05-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release Notes for Webmention for Craft CMS
 
+## Unreleased
+- “Source” and “Target” condition rules no longer have “has a value” or “is empty” operators.
+
 ## 1.0.3 – 2025-05-09
 - `authorName` values now use the h-card’s `nickname` property as a fallback. ([#10](https://github.com/matthiasott/webmention/pull/10))
 - Fixed a bug where webmention validation wasn’t catching `ConnectException` errors.

--- a/src/elements/conditions/HostConditionRule.php
+++ b/src/elements/conditions/HostConditionRule.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace matthiasott\webmention\elements\conditions;
+
+use Craft;
+use craft\base\conditions\BaseTextConditionRule;
+use craft\base\ElementInterface;
+use craft\elements\conditions\ElementConditionRuleInterface;
+use craft\elements\db\ElementQueryInterface;
+use craft\helpers\ArrayHelper;
+use matthiasott\webmention\elements\db\WebmentionQuery;
+use matthiasott\webmention\elements\Webmention;
+
+class HostConditionRule extends BaseTextConditionRule implements ElementConditionRuleInterface
+{
+    public function getLabel(): string
+    {
+        return Craft::t('webmention', 'Host');
+    }
+
+    public function getExclusiveQueryParams(): array
+    {
+        return ['host'];
+    }
+
+    protected function operators(): array
+    {
+        $operators = parent::operators();
+        ArrayHelper::removeValue($operators, self::OPERATOR_NOT_EMPTY);
+        ArrayHelper::removeValue($operators, self::OPERATOR_EMPTY);
+        return $operators;
+    }
+
+    public function modifyQuery(ElementQueryInterface $query): void
+    {
+        /** @var WebmentionQuery $query */
+        $query->host($this->paramValue());
+    }
+
+    public function matchElement(ElementInterface $element): bool
+    {
+        /** @var Webmention $element */
+        return $this->matchValue($element->host);
+    }
+}

--- a/src/elements/conditions/SourceConditionRule.php
+++ b/src/elements/conditions/SourceConditionRule.php
@@ -7,6 +7,7 @@ use craft\base\conditions\BaseTextConditionRule;
 use craft\base\ElementInterface;
 use craft\elements\conditions\ElementConditionRuleInterface;
 use craft\elements\db\ElementQueryInterface;
+use craft\helpers\ArrayHelper;
 use matthiasott\webmention\elements\db\WebmentionQuery;
 use matthiasott\webmention\elements\Webmention;
 
@@ -20,6 +21,14 @@ class SourceConditionRule extends BaseTextConditionRule implements ElementCondit
     public function getExclusiveQueryParams(): array
     {
         return ['source'];
+    }
+
+    protected function operators(): array
+    {
+        $operators = parent::operators();
+        ArrayHelper::removeValue($operators, self::OPERATOR_NOT_EMPTY);
+        ArrayHelper::removeValue($operators, self::OPERATOR_EMPTY);
+        return $operators;
     }
 
     public function modifyQuery(ElementQueryInterface $query): void

--- a/src/elements/conditions/TargetConditionRule.php
+++ b/src/elements/conditions/TargetConditionRule.php
@@ -7,6 +7,7 @@ use craft\base\conditions\BaseTextConditionRule;
 use craft\base\ElementInterface;
 use craft\elements\conditions\ElementConditionRuleInterface;
 use craft\elements\db\ElementQueryInterface;
+use craft\helpers\ArrayHelper;
 use matthiasott\webmention\elements\db\WebmentionQuery;
 use matthiasott\webmention\elements\Webmention;
 
@@ -20,6 +21,14 @@ class TargetConditionRule extends BaseTextConditionRule implements ElementCondit
     public function getExclusiveQueryParams(): array
     {
         return ['target'];
+    }
+
+    protected function operators(): array
+    {
+        $operators = parent::operators();
+        ArrayHelper::removeValue($operators, self::OPERATOR_NOT_EMPTY);
+        ArrayHelper::removeValue($operators, self::OPERATOR_EMPTY);
+        return $operators;
     }
 
     public function modifyQuery(ElementQueryInterface $query): void

--- a/src/elements/conditions/WebmentionCondition.php
+++ b/src/elements/conditions/WebmentionCondition.php
@@ -12,6 +12,7 @@ class WebmentionCondition extends ElementCondition
             ...parent::selectableConditionRules(),
             AuthorNameConditionRule::class,
             AuthorUrlConditionRule::class,
+            HostConditionRule::class,
             PublishedConditionRule::class,
             SourceConditionRule::class,
             TargetConditionRule::class,


### PR DESCRIPTION
- Adds a new “Host” condition rule type
- Removes the “has a value” and “is empty” operators from “Source” and “Target” condition rules, since they will always have a value.