### PR TITLE
More eager loading

### DIFF
--- a/src/behaviors/ElementBehavior.php
+++ b/src/behaviors/ElementBehavior.php
@@ -17,6 +17,11 @@ class ElementBehavior extends Behavior
      */
     public function getWebmentions(): array
     {
+        if ($this->owner->hasEagerLoadedElements('webmentions')) {
+            /** @phpstan-ignore-next-line */
+            return $this->owner->getEagerLoadedElements('webmentions')->all();
+        }
+
         return Plugin::getInstance()->webmentions->getWebmentionsForElement($this->owner);
     }
 
@@ -26,6 +31,15 @@ class ElementBehavior extends Behavior
      */
     public function getWebmentionsByType(?string $type = null): array
     {
+        if ($type === null) {
+            return $this->getWebmentions();
+        }
+
+        if ($this->owner->hasEagerLoadedElements("webmentions:$type")) {
+            /** @phpstan-ignore-next-line */
+            return $this->owner->getEagerLoadedElements("webmentions:$type")->all();
+        }
+
         return Plugin::getInstance()->webmentions->getWebmentionsForElementByType($this->owner, $type);
     }
 }

--- a/src/behaviors/ElementBehavior.php
+++ b/src/behaviors/ElementBehavior.php
@@ -26,6 +26,15 @@ class ElementBehavior extends Behavior
     }
 
     /**
+     * @return int
+     */
+    public function getTotalWebmentions(): int
+    {
+        $count = $this->owner->getEagerLoadedElementCount('webmentions');
+        return $count ?? Plugin::getInstance()->webmentions->getTotalWebmentionsForElement($this->owner);
+    }
+
+    /**
      * @param string|null $type
      * @return Webmention[]
      */
@@ -41,5 +50,19 @@ class ElementBehavior extends Behavior
         }
 
         return Plugin::getInstance()->webmentions->getWebmentionsForElementByType($this->owner, $type);
+    }
+
+    /**
+     * @param string|null $type
+     * @return int
+     */
+    public function getTotalWebmentionsByType(?string $type = null): int
+    {
+        if ($type === null) {
+            return $this->getTotalWebmentions();
+        }
+
+        $count = $this->owner->getEagerLoadedElementCount("webmentions:$type");
+        return $count ?? Plugin::getInstance()->webmentions->getTotalWebmentionsForElementByType($this->owner, $type);
     }
 }

--- a/src/services/Webmentions.php
+++ b/src/services/Webmentions.php
@@ -53,6 +53,21 @@ class Webmentions extends Component
     }
 
     /**
+     * Returns the total webmentions for an element
+     *
+     * @param ElementInterface $element
+     * @return int
+     * @since 1.0.4
+     */
+    public function getTotalWebmentionsForElement(ElementInterface $element): int
+    {
+        return Webmention::find()
+            ->targetId($element->id)
+            ->targetSiteId($element::isLocalized() ? $element->siteId : null)
+            ->count();
+    }
+
+    /**
      * Gets all available webmentions for an element by type (e.g. `mention`, `like`, or `repost`)
      *
      * @param ElementInterface $element
@@ -66,6 +81,23 @@ class Webmentions extends Component
             ->targetSiteId($element::isLocalized() ? $element->siteId : null)
             ->type($type)
             ->all();
+    }
+
+    /**
+     * Returns the total webmentions for an element by type (e.g. `mention`, `like`, or `repost`)
+     *
+     * @param ElementInterface $element
+     * @param string|null $type
+     * @return int
+     * @since 1.0.4
+     */
+    public function getTotalWebmentionsForElementByType(ElementInterface $element, ?string $type = null): int
+    {
+        return Webmention::find()
+            ->targetId($element->id)
+            ->targetSiteId($element::isLocalized() ? $element->siteId : null)
+            ->type($type)
+            ->count();
     }
 
     /**


### PR DESCRIPTION
Adds support for eager-loading elements with the following values passed into the `with` param:

- `webmentions`
- `webmentions:<type>` (e.g. `webmentions:like`)

```twig
{% set entries = craft.entries()
  .section('blog')
  .with(['webmentions:like', 'webmentions:comment'])
  .all() %}
```

With that in place, calling `element.getWebmentions()` or `element.getWebmentionsByType()` will return the eager-loaded webmentions, rather than querying for them for each individual element.

New `element.getTotalWebmentions()` and `getTotalWebmentionsByType()` methods have also been added, which support eager-loading as well.

If all you want to do is output the total, you can set the `with` path’s criteria to `{count: true}`:

```twig
{% set entries = craft.entries()
  .section('blog')
  .with([
    ['webmentions:like', {count: true}],
    ['webmentions:comment', {count: true}],
  ])
  .all() %}
```
